### PR TITLE
Address static analysis issues encountered downstream

### DIFF
--- a/phpstan-baseline-7.4.neon
+++ b/phpstan-baseline-7.4.neon
@@ -1086,7 +1086,7 @@ parameters:
 			path: src/Toolkit/Core/Pipeline.php
 
 		-
-			message: "#^Parameter \\#1 \\$in of method Salient\\\\Core\\\\ArrayMapper\\:\\:map\\(\\) expects array, TInput\\|TOutput given\\.$#"
+			message: "#^Parameter \\#1 \\$in of method Salient\\\\Core\\\\ArrayMapper\\:\\:map\\(\\) expects array, TInput given\\.$#"
 			count: 1
 			path: src/Toolkit/Core/Pipeline.php
 
@@ -1926,13 +1926,13 @@ parameters:
 			path: src/Toolkit/PhpDoc/PhpDocTag.php
 
 		-
-			message: "#^Method Salient\\\\Sync\\\\AbstractSyncDefinition\\:\\:getSyncOperationClosure\\(\\) should return \\(Closure\\(Salient\\\\Contract\\\\Sync\\\\SyncContextInterface, int\\|string\\|null, mixed \\.\\.\\.\\)\\: TEntity\\)\\|\\(Closure\\(Salient\\\\Contract\\\\Sync\\\\SyncContextInterface, TEntity, mixed \\.\\.\\.\\)\\: TEntity\\)\\|\\(Closure\\(Salient\\\\Contract\\\\Sync\\\\SyncContextInterface, iterable\\<TEntity\\>, mixed \\.\\.\\.\\)\\: iterable\\<TEntity\\>\\)\\|null but returns Closure\\(Salient\\\\Contract\\\\Sync\\\\SyncContextInterface, mixed \\.\\.\\.\\)\\: \\(iterable\\<TEntity\\>\\|TEntity\\)\\.$#"
-			count: 2
+			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
+			count: 1
 			path: src/Toolkit/Sync/AbstractSyncDefinition.php
 
 		-
-			message: "#^Parameter \\#1 \\$closure of method Salient\\\\Contract\\\\Pipeline\\\\BasePipelineInterface\\<array,TEntity of Salient\\\\Contract\\\\Sync\\\\SyncEntityInterface,array\\<int, array\\<TEntity of Salient\\\\Contract\\\\Sync\\\\SyncEntityInterface\\>\\|int\\|Salient\\\\Contract\\\\Sync\\\\SyncContextInterface\\|string\\|\\(TEntity of Salient\\\\Contract\\\\Sync\\\\SyncEntityInterface\\)\\|null\\>\\>\\:\\:then\\(\\) expects Closure\\(array\\|TEntity, Salient\\\\Contract\\\\Pipeline\\\\PipelineInterface\\<array, TEntity, array\\{0\\: 1\\|2\\|4\\|8\\|16\\|32\\|64\\|128, 1\\: Salient\\\\Contract\\\\Sync\\\\SyncContextInterface, 2\\?\\: array\\<TEntity\\>\\|int\\|string\\|TEntity\\|null\\}\\>, array\\{0\\: 1\\|2\\|4\\|8\\|16\\|32\\|64\\|128, 1\\: Salient\\\\Contract\\\\Sync\\\\SyncContextInterface, 2\\?\\: array\\<TEntity\\>\\|int\\|string\\|TEntity\\|null\\}\\)\\: TEntity, Closure\\(array, Salient\\\\Contract\\\\Pipeline\\\\PipelineInterface, mixed\\)\\: TEntity given\\.$#"
-			count: 1
+			message: "#^Method Salient\\\\Sync\\\\AbstractSyncDefinition\\:\\:getSyncOperationClosure\\(\\) should return \\(Closure\\(Salient\\\\Contract\\\\Sync\\\\SyncContextInterface, int\\|string\\|null, mixed \\.\\.\\.\\)\\: TEntity\\)\\|\\(Closure\\(Salient\\\\Contract\\\\Sync\\\\SyncContextInterface, TEntity, mixed \\.\\.\\.\\)\\: TEntity\\)\\|\\(Closure\\(Salient\\\\Contract\\\\Sync\\\\SyncContextInterface, iterable\\<TEntity\\>, mixed \\.\\.\\.\\)\\: iterable\\<TEntity\\>\\)\\|null but returns Closure\\(Salient\\\\Contract\\\\Sync\\\\SyncContextInterface, mixed \\.\\.\\.\\)\\: \\(iterable\\<TEntity\\>\\|TEntity\\)\\.$#"
+			count: 2
 			path: src/Toolkit/Sync/AbstractSyncDefinition.php
 
 		-
@@ -2186,13 +2186,8 @@ parameters:
 			path: src/Toolkit/Sync/Support/SyncContext.php
 
 		-
-			message: "#^Method Salient\\\\Sync\\\\Support\\\\SyncContext\\:\\:reduceFilterValue\\(\\) should return array\\<int\\|string\\>\\|int\\|string\\|T but returns array\\<int\\<0, max\\>, int\\|string\\|null\\>\\.$#"
-			count: 1
-			path: src/Toolkit/Sync/Support/SyncContext.php
-
-		-
-			message: "#^Method Salient\\\\Sync\\\\Support\\\\SyncContext\\:\\:reduceFilterValue\\(\\) should return array\\<int\\|string\\>\\|int\\|string\\|T but returns int\\|string\\|null\\.$#"
-			count: 1
+			message: "#^Method Salient\\\\Sync\\\\Support\\\\SyncContext\\:\\:doGetFilter\\(\\) should return array\\<bool\\|DateTimeInterface\\|float\\|int\\|string\\|null\\>\\|bool\\|DateTimeInterface\\|float\\|int\\|string\\|null but returns mixed\\.$#"
+			count: 2
 			path: src/Toolkit/Sync/Support/SyncContext.php
 
 		-

--- a/phpstan-baseline-8.3.neon
+++ b/phpstan-baseline-8.3.neon
@@ -1051,7 +1051,7 @@ parameters:
 			path: src/Toolkit/Core/Pipeline.php
 
 		-
-			message: "#^Parameter \\#1 \\$in of method Salient\\\\Core\\\\ArrayMapper\\:\\:map\\(\\) expects array, TInput\\|TOutput given\\.$#"
+			message: "#^Parameter \\#1 \\$in of method Salient\\\\Core\\\\ArrayMapper\\:\\:map\\(\\) expects array, TInput given\\.$#"
 			count: 1
 			path: src/Toolkit/Core/Pipeline.php
 
@@ -1861,13 +1861,13 @@ parameters:
 			path: src/Toolkit/PhpDoc/PhpDocTag.php
 
 		-
-			message: "#^Method Salient\\\\Sync\\\\AbstractSyncDefinition\\:\\:getSyncOperationClosure\\(\\) should return \\(Closure\\(Salient\\\\Contract\\\\Sync\\\\SyncContextInterface, int\\|string\\|null, mixed \\.\\.\\.\\)\\: TEntity\\)\\|\\(Closure\\(Salient\\\\Contract\\\\Sync\\\\SyncContextInterface, TEntity, mixed \\.\\.\\.\\)\\: TEntity\\)\\|\\(Closure\\(Salient\\\\Contract\\\\Sync\\\\SyncContextInterface, iterable\\<TEntity\\>, mixed \\.\\.\\.\\)\\: iterable\\<TEntity\\>\\)\\|null but returns Closure\\(Salient\\\\Contract\\\\Sync\\\\SyncContextInterface, mixed \\.\\.\\.\\)\\: \\(iterable\\<TEntity\\>\\|TEntity\\)\\.$#"
-			count: 2
+			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
+			count: 1
 			path: src/Toolkit/Sync/AbstractSyncDefinition.php
 
 		-
-			message: "#^Parameter \\#1 \\$closure of method Salient\\\\Contract\\\\Pipeline\\\\BasePipelineInterface\\<array,TEntity of Salient\\\\Contract\\\\Sync\\\\SyncEntityInterface,array\\<int, array\\<TEntity of Salient\\\\Contract\\\\Sync\\\\SyncEntityInterface\\>\\|int\\|Salient\\\\Contract\\\\Sync\\\\SyncContextInterface\\|string\\|\\(TEntity of Salient\\\\Contract\\\\Sync\\\\SyncEntityInterface\\)\\|null\\>\\>\\:\\:then\\(\\) expects Closure\\(array\\|TEntity, Salient\\\\Contract\\\\Pipeline\\\\PipelineInterface\\<array, TEntity, array\\{0\\: 1\\|2\\|4\\|8\\|16\\|32\\|64\\|128, 1\\: Salient\\\\Contract\\\\Sync\\\\SyncContextInterface, 2\\?\\: array\\<TEntity\\>\\|int\\|string\\|TEntity\\|null\\}\\>, array\\{0\\: 1\\|2\\|4\\|8\\|16\\|32\\|64\\|128, 1\\: Salient\\\\Contract\\\\Sync\\\\SyncContextInterface, 2\\?\\: array\\<TEntity\\>\\|int\\|string\\|TEntity\\|null\\}\\)\\: TEntity, Closure\\(array, Salient\\\\Contract\\\\Pipeline\\\\PipelineInterface, mixed\\)\\: TEntity given\\.$#"
-			count: 1
+			message: "#^Method Salient\\\\Sync\\\\AbstractSyncDefinition\\:\\:getSyncOperationClosure\\(\\) should return \\(Closure\\(Salient\\\\Contract\\\\Sync\\\\SyncContextInterface, int\\|string\\|null, mixed \\.\\.\\.\\)\\: TEntity\\)\\|\\(Closure\\(Salient\\\\Contract\\\\Sync\\\\SyncContextInterface, TEntity, mixed \\.\\.\\.\\)\\: TEntity\\)\\|\\(Closure\\(Salient\\\\Contract\\\\Sync\\\\SyncContextInterface, iterable\\<TEntity\\>, mixed \\.\\.\\.\\)\\: iterable\\<TEntity\\>\\)\\|null but returns Closure\\(Salient\\\\Contract\\\\Sync\\\\SyncContextInterface, mixed \\.\\.\\.\\)\\: \\(iterable\\<TEntity\\>\\|TEntity\\)\\.$#"
+			count: 2
 			path: src/Toolkit/Sync/AbstractSyncDefinition.php
 
 		-
@@ -2116,13 +2116,8 @@ parameters:
 			path: src/Toolkit/Sync/Support/SyncContext.php
 
 		-
-			message: "#^Method Salient\\\\Sync\\\\Support\\\\SyncContext\\:\\:reduceFilterValue\\(\\) should return array\\<int\\|string\\>\\|int\\|string\\|T but returns array\\<int\\<0, max\\>, int\\|string\\|null\\>\\.$#"
-			count: 1
-			path: src/Toolkit/Sync/Support/SyncContext.php
-
-		-
-			message: "#^Method Salient\\\\Sync\\\\Support\\\\SyncContext\\:\\:reduceFilterValue\\(\\) should return array\\<int\\|string\\>\\|int\\|string\\|T but returns int\\|string\\|null\\.$#"
-			count: 1
+			message: "#^Method Salient\\\\Sync\\\\Support\\\\SyncContext\\:\\:doGetFilter\\(\\) should return array\\<bool\\|DateTimeInterface\\|float\\|int\\|string\\|null\\>\\|bool\\|DateTimeInterface\\|float\\|int\\|string\\|null but returns mixed\\.$#"
+			count: 2
 			path: src/Toolkit/Sync/Support/SyncContext.php
 
 		-

--- a/src/Toolkit/Contract/Pipeline/BasePipelineInterface.php
+++ b/src/Toolkit/Contract/Pipeline/BasePipelineInterface.php
@@ -51,7 +51,7 @@ interface BasePipelineInterface extends Chainable, Immutable
      *   {@see PipelineInterface::then()}, if applicable
      * - throw an exception
      *
-     * @param (Closure(TInput|TOutput $payload, Closure $next, static $pipeline, TArgument $arg): (TInput|TOutput))|PipeInterface<TInput,TOutput,TArgument>|class-string<PipeInterface<TInput,TOutput,TArgument>> ...$pipes
+     * @param (Closure(TInput $payload, Closure $next, static $pipeline, TArgument $arg): (TInput|TOutput))|(Closure(TOutput $payload, Closure $next, static $pipeline, TArgument $arg): TOutput)|PipeInterface<TInput,TOutput,TArgument>|class-string<PipeInterface<TInput,TOutput,TArgument>> ...$pipes
      * @return static
      */
     public function through(...$pipes);
@@ -59,7 +59,7 @@ interface BasePipelineInterface extends Chainable, Immutable
     /**
      * Add a simple closure to the pipeline
      *
-     * @param Closure(TInput|TOutput $payload, static $pipeline, TArgument $arg): (TInput|TOutput) $closure
+     * @param (Closure(TInput $payload, static $pipeline, TArgument $arg): (TInput|TOutput))|(Closure(TOutput $payload, static $pipeline, TArgument $arg): TOutput) $closure
      * @return static
      */
     public function throughClosure(Closure $closure);
@@ -80,7 +80,7 @@ interface BasePipelineInterface extends Chainable, Immutable
      * This method can only be called once per pipeline, and only if
      * {@see StreamPipelineInterface::collectThen()} is not also called.
      *
-     * @param Closure(TInput|TOutput $result, static $pipeline, TArgument $arg): TOutput $closure
+     * @param (Closure(TInput $result, static $pipeline, TArgument $arg): TOutput)|(Closure(TOutput $result, static $pipeline, TArgument $arg): TOutput) $closure
      * @return static
      */
     public function then(Closure $closure);
@@ -88,7 +88,7 @@ interface BasePipelineInterface extends Chainable, Immutable
     /**
      * Apply a closure to each result if then() hasn't already been called
      *
-     * @param Closure(TInput|TOutput $result, static $pipeline, TArgument $arg): TOutput $closure
+     * @param (Closure(TInput $result, static $pipeline, TArgument $arg): TOutput)|(Closure(TOutput $result, static $pipeline, TArgument $arg): TOutput) $closure
      * @return static
      */
     public function thenIf(Closure $closure);

--- a/src/Toolkit/Contract/Sync/SyncContextInterface.php
+++ b/src/Toolkit/Contract/Sync/SyncContextInterface.php
@@ -7,6 +7,7 @@ use Salient\Contract\Core\ProviderContextInterface;
 use Salient\Sync\Exception\SyncEntityRecursionException;
 use Salient\Sync\Exception\SyncInvalidFilterException;
 use Salient\Sync\AbstractSyncProvider;
+use DateTimeInterface;
 
 /**
  * The context within which sync entities are instantiated by a provider
@@ -26,12 +27,13 @@ interface SyncContextInterface extends ProviderContextInterface
      *
      * 1. One array argument (`fn(...$mandatoryArgs, array $filter)`)
      *
-     *    - Alphanumeric keys are converted to snake_case
-     *    - Keys containing characters other than letters, numbers, hyphens and
-     *      underscores, e.g. `'$orderby'`, are left as-is
-     *    - {@see SyncEntityInterface} objects are replaced with their
+     *    - Keys containing only letters, numbers, hyphens and underscores are
+     *      converted to snake_case
+     *    - Keys containing other characters, e.g. `'$orderby'`, are left as-is
+     *    - {@see SyncEntityInterface} instances are replaced with their
      *      respective IDs
-     *    - Empty keys (`''` after snake_case conversion) are invalid
+     *    - Empty and numeric keys (e.g. `''` or `'42'` after snake_case
+     *      conversion) are invalid
      *
      * 2. A list of identifiers (`fn(...$mandatoryArgs, int|string ...$ids)`)
      *
@@ -190,7 +192,7 @@ interface SyncContextInterface extends ProviderContextInterface
      *
      * @see SyncContextInterface::withArgs()
      *
-     * @return array<string,mixed>
+     * @return array<string,(int|string|DateTimeInterface|float|bool|null)[]|int|string|DateTimeInterface|float|bool|null>
      */
     public function getFilters(): array;
 
@@ -202,7 +204,8 @@ interface SyncContextInterface extends ProviderContextInterface
      * context via {@see ProviderContextInterface::withValue()}, it is returned
      * if there is no matching filter.
      *
-     * @return mixed `null` if the value has been claimed via
+     * @return (int|string|DateTimeInterface|float|bool|null)[]|int|string|DateTimeInterface|float|bool|null
+     * `null` if the value has been claimed via
      * {@see SyncContextInterface::claimFilter()} or wasn't passed to the
      * operation.
      *
@@ -222,10 +225,11 @@ interface SyncContextInterface extends ProviderContextInterface
      * context via {@see ProviderContextInterface::withValue()}, it is returned
      * if there is no matching filter.
      *
-     * @return mixed `null` if the value has already been claimed or wasn't
-     * passed to the operation.
-     *
      * @see SyncContextInterface::withArgs()
+     *
+     * @return (int|string|DateTimeInterface|float|bool|null)[]|int|string|DateTimeInterface|float|bool|null
+     * `null` if the value has already been claimed or wasn't passed to the
+     * operation.
      */
     public function claimFilter(string $key, bool $orValue = true);
 

--- a/src/Toolkit/Core/Pipeline.php
+++ b/src/Toolkit/Core/Pipeline.php
@@ -59,7 +59,7 @@ final class Pipeline implements
     private ?Closure $After = null;
 
     /**
-     * @var array<(Closure(TInput|TOutput $payload, Closure $next, static $pipeline, TArgument $arg): (TInput|TOutput))|PipeInterface<TInput,TOutput,TArgument>|class-string<PipeInterface<TInput,TOutput,TArgument>>>
+     * @var array<(Closure(TInput $payload, Closure $next, static $pipeline, TArgument $arg): (TInput|TOutput))|(Closure(TOutput $payload, Closure $next, static $pipeline, TArgument $arg): TOutput)|PipeInterface<TInput,TOutput,TArgument>|class-string<PipeInterface<TInput,TOutput,TArgument>>>
      */
     private array $Pipes = [];
 
@@ -74,7 +74,7 @@ final class Pipeline implements
     private array $ArrayMappers;
 
     /**
-     * @var (Closure(TInput|TOutput $result, static $pipeline, TArgument $arg): TOutput)|null
+     * @var (Closure(TInput $result, static $pipeline, TArgument $arg): TOutput)|(Closure(TOutput $result, static $pipeline, TArgument $arg): TOutput)|null
      */
     private ?Closure $Then = null;
 

--- a/src/Toolkit/Core/Utility/Get.php
+++ b/src/Toolkit/Core/Utility/Get.php
@@ -37,6 +37,8 @@ final class Get extends AbstractUtility
      *
      * @param T $value
      * @return (T is null ? never : T)
+     * @phpstan-param T|null $value
+     * @phpstan-return ($value is null ? never : T)
      */
     public static function notNull($value)
     {

--- a/src/Toolkit/Core/Utility/Test.php
+++ b/src/Toolkit/Core/Utility/Test.php
@@ -55,6 +55,20 @@ final class Test extends AbstractUtility
     }
 
     /**
+     * True if a value is an integer or would be cast to an integer if used as
+     * an array key
+     *
+     * @param mixed $value
+     */
+    public static function isNumericKey($value): bool
+    {
+        return is_int($value) ||
+            is_float($value) ||
+            is_bool($value) ||
+            (is_string($value) && Pcre::match('/^(-?[1-9][0-9]*|0)$/', $value));
+    }
+
+    /**
      * True if a value is a valid date string
      *
      * @param mixed $value

--- a/tests/unit/Toolkit/Core/Utility/StrTest.php
+++ b/tests/unit/Toolkit/Core/Utility/StrTest.php
@@ -347,6 +347,12 @@ final class StrTest extends TestCase
     public static function toCaseProvider(): array
     {
         return [
+            ['', null, '', '', '', ''],
+            ['0', null, '0', '0', '0', '0'],
+            [' 0 ', null, '0', '0', '0', '0'],
+            ['0.00', null, '0_00', '0-00', '000', '000'],
+            ['2e5', null, '2e5', '2e5', '2e5', '2e5'],
+            ['2.0e5', null, '2_0e5', '2-0e5', '20e5', '20e5'],
             ['**two words**', null, 'two_words', 'two-words', 'twoWords', 'TwoWords'],
             ['**Two_Words**', null, 'two_words', 'two-words', 'twoWords', 'TwoWords'],
             ['**TWO-WORDS**', null, 'two_words', 'two-words', 'twoWords', 'TwoWords'],

--- a/tests/unit/Toolkit/Core/Utility/TestTest.php
+++ b/tests/unit/Toolkit/Core/Utility/TestTest.php
@@ -106,4 +106,38 @@ final class TestTest extends TestCase
             [true, 71],
         ];
     }
+
+    /**
+     * @dataProvider isNumericKeyProvider
+     *
+     * @param mixed $value
+     */
+    public function testIsNumericKey(bool $expected, $value): void
+    {
+        $this->assertSame($expected, is_int(array_key_first([$value => 'foo'])));
+        $this->assertSame($expected, Test::isNumericKey($value));
+    }
+
+    /**
+     * @return array<array{bool,mixed}>
+     */
+    public static function isNumericKeyProvider(): array
+    {
+        return [
+            [false, null],
+            [false, ''],
+            [true, '-1'],
+            [false, '-0'],
+            [true, '0'],
+            [false, '+0'],
+            [false, '+1'],
+            [true, '123'],
+            [false, '0755'],
+            [false, 'abc'],
+            [true, 123],
+            [true, 12.34],
+            [true, true],
+            [true, false],
+        ];
+    }
 }


### PR DESCRIPTION
- Add `Test::isNumericKey()`
- In pipelines, accept closures with narrower parameter types
- In sync contexts, reject numeric keys in filters and specify the structure of a valid filter
- Add more `@template` workarounds for PHPStan and Intelephense