### PR TITLE
Fix issues related to adoption of tight declaration spacing

### DIFF
--- a/scripts/generate.php
+++ b/scripts/generate.php
@@ -125,6 +125,7 @@ foreach ($class->getReflectionConstants() as $constant) {
 }
 
 $args = [
+    '--collapse',
     '--force',
     ...array_slice($_SERVER['argv'], 1),
 ];

--- a/src/Sli/Command/Generate/Concept/GenerateCommand.php
+++ b/src/Sli/Command/Generate/Concept/GenerateCommand.php
@@ -69,6 +69,7 @@ abstract class GenerateCommand extends Command
     protected ?string $Description = null;
 
     protected bool $ApiTag = false;
+    protected bool $Collapse = false;
     protected bool $ToStdout = false;
     protected bool $Check = false;
     protected bool $ReplaceIfExists = false;
@@ -232,6 +233,11 @@ abstract class GenerateCommand extends Command
                 ->short('a')
                 ->description("Add an `@api` tag to the $outputType")
                 ->bindTo($this->ApiTag),
+            CliOption::build()
+                ->long('collapse')
+                ->short('C')
+                ->description("Collapse one-line declarations in the $outputType")
+                ->bindTo($this->Collapse),
             CliOption::build()
                 ->long('stdout')
                 ->short('s')

--- a/src/Sli/Command/Generate/GenerateSyncEntity.php
+++ b/src/Sli/Command/Generate/GenerateSyncEntity.php
@@ -462,12 +462,21 @@ EOF)
         $blocks = [];
 
         foreach ($properties as $property => $type) {
-            $blocks[] = <<<EOF
+            $blocks[] = $this->Collapse
+                ? <<<EOF
+/** @var $type */
+$visibility \$$property;
+EOF
+                : <<<EOF
 /**
  * @var $type
  */
 $visibility \$$property;
 EOF;
+        }
+
+        if ($this->Collapse) {
+            $blocks = [implode(\PHP_EOL, $blocks)];
         }
 
         if ($parent) {


### PR DESCRIPTION
- Add `--collapse` option to `sli generate` commands
- Collapse generated sync entity properties when `--collapse` is given