### PR TITLE
Fix empty string date handling issues

### DIFF
--- a/phpstan-baseline-7.4.neon
+++ b/phpstan-baseline-7.4.neon
@@ -831,16 +831,6 @@ parameters:
 			path: tests/unit/Toolkit/Core/Concern/ConstructibleTrait/ConstructibleTraitTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$date of method Salient\\\\Core\\\\DateFormatter\\:\\:format\\(\\) expects DateTimeInterface, DateTimeImmutable\\|null given\\.$#"
-			count: 2
-			path: tests/unit/Toolkit/Core/DateFormatterTest.php
-
-		-
-			message: "#^Cannot call method format\\(\\) on DateTimeImmutable\\|null\\.$#"
-			count: 1
-			path: tests/unit/Toolkit/Core/DotNetDateParserTest.php
-
-		-
 			message: "#^Cannot access offset 0 on array\\{float, int\\}\\|float\\|int\\.$#"
 			count: 8
 			path: tests/unit/Toolkit/Core/MetricCollectorTest.php

--- a/phpstan-baseline-8.3.neon
+++ b/phpstan-baseline-8.3.neon
@@ -781,16 +781,6 @@ parameters:
 			path: tests/unit/Toolkit/Core/Concern/ConstructibleTrait/ConstructibleTraitTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$date of method Salient\\\\Core\\\\DateFormatter\\:\\:format\\(\\) expects DateTimeInterface, DateTimeImmutable\\|null given\\.$#"
-			count: 2
-			path: tests/unit/Toolkit/Core/DateFormatterTest.php
-
-		-
-			message: "#^Cannot call method format\\(\\) on DateTimeImmutable\\|null\\.$#"
-			count: 1
-			path: tests/unit/Toolkit/Core/DotNetDateParserTest.php
-
-		-
 			message: "#^Cannot access offset 0 on array\\{float, int\\}\\|float\\|int\\.$#"
 			count: 8
 			path: tests/unit/Toolkit/Core/MetricCollectorTest.php

--- a/src/Sli/Command/Generate/GenerateSyncEntity.php
+++ b/src/Sli/Command/Generate/GenerateSyncEntity.php
@@ -347,7 +347,7 @@ EOF)
                     continue;
                 }
 
-                if (is_string($value) && $dateFormatter->parse($value)) {
+                if (is_string($value) && trim($value) !== '' && $dateFormatter->parse($value)) {
                     $properties[$key] = $this->getFqcnAlias(DateTimeInterface::class) . '|null';
                     continue;
                 }

--- a/src/Toolkit/Contract/Core/DateFormatterInterface.php
+++ b/src/Toolkit/Contract/Core/DateFormatterInterface.php
@@ -16,9 +16,7 @@ interface DateFormatterInterface
     public function format(DateTimeInterface $date): string;
 
     /**
-     * Convert a string to a date and time, if possible
-     *
-     * Returns `null` if `$value` cannot be parsed.
+     * Convert a value to a date and time, or return null if it can't be parsed
      */
     public function parse(string $value): ?DateTimeImmutable;
 }

--- a/src/Toolkit/Contract/Core/DateParserInterface.php
+++ b/src/Toolkit/Contract/Core/DateParserInterface.php
@@ -11,13 +11,21 @@ use DateTimeZone;
 interface DateParserInterface
 {
     /**
-     * Convert a string to a date and time, if possible
+     * Convert a value to a date and time, or return null if it can't be parsed
      *
-     * Returns `null` if `$value` cannot be parsed.
+     * If the value does not specify a timezone, one of the following is used
+     * during parsing:
      *
-     * @param DateTimeZone|null $timezone Applied to the date and time if given,
-     * otherwise timezone information in `$value` should be used if present, or
-     * a default timezone may be used.
+     * - `$timezone` (if given)
+     * - the parser's default timezone (if applicable)
+     * - the script's default timezone (if set)
+     * - `UTC`
+     *
+     * If `$timezone` is given, it is applied to the date and time before it is
+     * returned.
      */
-    public function parse(string $value, ?DateTimeZone $timezone = null): ?DateTimeImmutable;
+    public function parse(
+        string $value,
+        ?DateTimeZone $timezone = null
+    ): ?DateTimeImmutable;
 }

--- a/src/Toolkit/Core/DateParser.php
+++ b/src/Toolkit/Core/DateParser.php
@@ -3,6 +3,7 @@
 namespace Salient\Core;
 
 use Salient\Contract\Core\DateParserInterface;
+use Salient\Utility\Test;
 use DateTimeImmutable;
 use DateTimeZone;
 
@@ -18,9 +19,12 @@ final class DateParser implements DateParserInterface
      */
     public function parse(string $value, ?DateTimeZone $timezone = null): ?DateTimeImmutable
     {
-        $date = date_create_immutable($value, $timezone);
-        if ($date === false) {
+        if (!Test::isDateString($value)) {
             return null;
+        }
+        $date = new DateTimeImmutable($value, $timezone);
+        if ($timezone) {
+            return $date->setTimezone($timezone);
         }
         return $date;
     }

--- a/tests/unit/Toolkit/Core/DateFormatterTest.php
+++ b/tests/unit/Toolkit/Core/DateFormatterTest.php
@@ -3,50 +3,37 @@
 namespace Salient\Tests\Core;
 
 use Salient\Core\DateFormatter;
-use Salient\Core\DotNetDateParser;
 use Salient\Tests\TestCase;
+use DateTimeImmutable;
 use DateTimeInterface;
+use DateTimeZone;
 
 /**
  * @covers \Salient\Core\DateFormatter
  */
 final class DateFormatterTest extends TestCase
 {
-    public function testDotNet(): void
+    /**
+     * @dataProvider formatProvider
+     */
+    public function testFormat(string $expected, string $tzExpected, DateTimeInterface $date): void
     {
-        $formatter = new DateFormatter(DateTimeInterface::RFC3339_EXTENDED, null, new DotNetDateParser());
-        $formatter2 = new DateFormatter(DateTimeInterface::RFC3339_EXTENDED, 'Australia/Sydney', new DotNetDateParser());
+        $tz = new DateTimeZone('Australia/Sydney');
+        $formatter = new DateFormatter(DateTimeInterface::RFC3339_EXTENDED);
+        $tzFormatter = new DateFormatter(DateTimeInterface::RFC3339_EXTENDED, $tz);
+        $this->assertSame($expected, $formatter->format($date));
+        $this->assertSame($tzExpected, $tzFormatter->format($date));
+    }
 
-        $data = [
-            '/Date(1530144000000+0530)/',
-            '/Date(1603152000000)/',
-            '/Date(1668143569876+1100)/'
+    /**
+     * @return array<array{string,string,DateTimeInterface}>
+     */
+    public static function formatProvider(): array
+    {
+        return [
+            ['2018-06-28T05:30:00.000+05:30', '2018-06-28T10:00:00.000+10:00', new DateTimeImmutable('2018-06-28T05:30:00.000+05:30')],
+            ['2020-10-20T00:00:00.000+00:00', '2020-10-20T11:00:00.000+11:00', new DateTimeImmutable('2020-10-20T00:00:00.000+00:00')],
+            ['2022-11-11T16:12:49.876+11:00', '2022-11-11T16:12:49.876+11:00', new DateTimeImmutable('2022-11-11T16:12:49.876+11:00')],
         ];
-
-        $this->assertEquals(
-            [
-                '2018-06-28T05:30:00.000+05:30',
-                '2020-10-20T00:00:00.000+00:00',
-                '2022-11-11T16:12:49.876+11:00',
-            ],
-            array_map(
-                fn(string $date) =>
-                    $formatter->format($formatter->parse($date)),
-                $data
-            )
-        );
-
-        $this->assertEquals(
-            [
-                '2018-06-28T10:00:00.000+10:00',
-                '2020-10-20T11:00:00.000+11:00',
-                '2022-11-11T16:12:49.876+11:00',
-            ],
-            array_map(
-                fn(string $date) =>
-                    $formatter2->format($formatter2->parse($date)),
-                $data
-            )
-        );
     }
 }

--- a/tests/unit/Toolkit/Core/DateParserTest.php
+++ b/tests/unit/Toolkit/Core/DateParserTest.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+
+namespace Salient\Tests\Core;
+
+use Salient\Core\DateParser;
+use Salient\Tests\TestCase;
+use DateTimeInterface;
+use DateTimeZone;
+
+/**
+ * @covers \Salient\Core\DateParser
+ */
+final class DateParserTest extends TestCase
+{
+    /**
+     * @dataProvider parseProvider
+     */
+    public function testParse(?string $expected, string $value, ?DateTimeZone $timezone = null): void
+    {
+        $parser = new DateParser();
+        $actual = $parser->parse($value, $timezone);
+        if ($expected === null) {
+            $this->assertNull($actual);
+            return;
+        }
+        $this->assertNotNull($actual);
+        $this->assertSame($expected, $actual->format(DateTimeInterface::RFC3339_EXTENDED));
+    }
+
+    /**
+     * @return array<array{string|null,string,2?:DateTimeZone|null}>
+     */
+    public static function parseProvider(): array
+    {
+        $tz = new DateTimeZone('Australia/Sydney');
+
+        return [
+            [null, ''],
+            ['2018-06-28T00:00:00.000+00:00', '23 June 2018 +5 day'],
+            ['2018-06-28T00:00:00.000+10:00', '23 June 2018 +5 day', $tz],
+            ['2018-06-28T05:42:49.876+05:30', '2018-06-28 05:42:49.876 +05:30'],
+            ['2018-06-28T10:12:49.876+10:00', '2018-06-28 05:42:49.876 +05:30', $tz],
+            ['2022-11-11T05:12:49.876+00:00', '@1668143569.876000'],
+            ['2022-11-11T16:12:49.876+11:00', '@1668143569.876000', $tz],
+        ];
+    }
+}

--- a/tests/unit/Toolkit/Core/DotNetDateParserTest.php
+++ b/tests/unit/Toolkit/Core/DotNetDateParserTest.php
@@ -23,6 +23,7 @@ final class DotNetDateParserTest extends TestCase
             $this->assertNull($actual);
             return;
         }
+        $this->assertNotNull($actual);
         $this->assertSame($expected, $actual->format(DateTimeInterface::RFC3339_EXTENDED));
     }
 


### PR DESCRIPTION
- Core: Fix `DateParser::parse()` issue where empty strings are interpreted as `'now'`
- Sli: Improve data type detection in `generate sync entity` command