### PR TITLE
Adopt "^ " instead of "? " as the default warning prefix

### DIFF
--- a/docs/Console.md
+++ b/docs/Console.md
@@ -51,7 +51,7 @@ target, e.g. by calling [registerTarget()][registerTarget], before any other
 | `Console` method | `ConsoleLevel`  | Message prefix | Default output target     |
 | ---------------- | --------------- | -------------- | ------------------------- |
 | `error[Once]()`  | `ERROR` = `3`   | ` !  `         | `STDERR`                  |
-| `warn[Once]()`   | `WARNING` = `4` | ` ?  `         | `STDERR`                  |
+| `warn[Once]()`   | `WARNING` = `4` | ` ^  `         | `STDERR`                  |
 | `info[Once]()`   | `NOTICE` = `5`  | ` ➤  `         | `STDOUT`                  |
 | `log[Once]()`    | `INFO` = `6`    | ` -  `         | `STDOUT`                  |
 | `debug[Once]()`  | `DEBUG` = `7`   | ` :  `         | `STDOUT` (if `DEBUG` set) |

--- a/src/Toolkit/Console/ConsoleFormatter.php
+++ b/src/Toolkit/Console/ConsoleFormatter.php
@@ -31,7 +31,7 @@ final class ConsoleFormatter implements FormatterInterface
         Level::ALERT => '! ',  // U+0021
         Level::CRITICAL => '! ',  // U+0021
         Level::ERROR => '! ',  // U+0021
-        Level::WARNING => '? ',  // U+003F
+        Level::WARNING => '^ ',  // U+005E
         Level::NOTICE => '➤ ',  // U+27A4
         Level::INFO => '- ',  // U+002D
         Level::DEBUG => ': ',  // U+003A

--- a/src/Toolkit/Contract/Console/ConsoleWriterInterface.php
+++ b/src/Toolkit/Contract/Console/ConsoleWriterInterface.php
@@ -154,7 +154,7 @@ interface ConsoleWriterInterface
     );
 
     /**
-     * Print "? $msg1 $msg2" with level WARNING
+     * Print "^ $msg1 $msg2" with level WARNING
      *
      * @return $this
      */
@@ -166,7 +166,7 @@ interface ConsoleWriterInterface
     );
 
     /**
-     * Print "? $msg1 $msg2" with level WARNING once per run
+     * Print "^ $msg1 $msg2" with level WARNING once per run
      *
      * @return $this
      */

--- a/src/Toolkit/Core/Facade/Console.php
+++ b/src/Toolkit/Core/Facade/Console.php
@@ -54,8 +54,8 @@ use Throwable;
  * @method static ConsoleWriterInterface registerTarget(ConsoleTargetInterface $target, array<Level::*> $levels = LevelGroup::ALL) Register a target to receive console output
  * @method static ConsoleWriterInterface setTargetPrefix(string|null $prefix, int-mask-of<ConsoleTargetTypeFlag::*> $flags = 0) Set or unset the prefix applied to each line of output by any registered targets that implement ConsoleTargetPrefixInterface
  * @method static ConsoleWriterInterface summary(string $finishedText = 'Command finished', string $successText = 'without errors', bool $withResourceUsage = false, bool $withoutErrorCount = false, bool $withStandardMessageType = false) Print a "command finished" message with a summary of errors, warnings and resource usage
- * @method static ConsoleWriterInterface warn(string $msg1, string|null $msg2 = null, Throwable|null $ex = null, bool $count = true) Print "? $msg1 $msg2" with level WARNING
- * @method static ConsoleWriterInterface warnOnce(string $msg1, string|null $msg2 = null, Throwable|null $ex = null, bool $count = true) Print "? $msg1 $msg2" with level WARNING once per run
+ * @method static ConsoleWriterInterface warn(string $msg1, string|null $msg2 = null, Throwable|null $ex = null, bool $count = true) Print "^ $msg1 $msg2" with level WARNING
+ * @method static ConsoleWriterInterface warnOnce(string $msg1, string|null $msg2 = null, Throwable|null $ex = null, bool $count = true) Print "^ $msg1 $msg2" with level WARNING once per run
  *
  * @api
  *

--- a/src/Toolkit/Http/HttpHeaders.php
+++ b/src/Toolkit/Http/HttpHeaders.php
@@ -798,7 +798,7 @@ REGEX;
             return '';
         }
         $line = implode(', ', $values);
-        if (!($first | $last | $one)) {
+        if (!($first || $last || $one)) {
             return $line;
         }
         $values = Str::splitDelimited(',', $line);


### PR DESCRIPTION
"? " implies a question is being asked, which `Console` may actually do in the future.